### PR TITLE
Trim whitespace from username

### DIFF
--- a/src/components/UsernameForm/index.js
+++ b/src/components/UsernameForm/index.js
@@ -49,9 +49,9 @@ class UsernameForm extends Component {
   handleSubmit = e => {
     e.preventDefault();
 
-    const username = this.state.username;
+    const username = this.state.username.trim();
 
-    if (username.trim().length === 0) {
+    if (username.length === 0) {
       return;
     }
     const userUrl = this.getUserUrl(username);


### PR DESCRIPTION
## Issue

Previous code didn't actually trim whitespaces. It only checked for empty input field after trimming. Now if end users accidentally enters whitespace in front of their username, they will be see the result. 
e.g: '  sbimochan' 

## Usage Changes
N/A

## Screenshot

![Screen Shot 2019-10-29 at 3 05 30 PM](https://user-images.githubusercontent.com/11685953/67753906-95954100-fa5d-11e9-964f-7bc5fad16e2c.jpg)

P.S Sorry @mesaugat for using your image without permission. 😄